### PR TITLE
Lowered minSdkVersion to 14

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.dgmltn.upnpbrowser"
-        minSdkVersion 21
+        minSdkVersion 14
         targetSdkVersion 23
         versionCode 2
         versionName "2"


### PR DESCRIPTION
To allow running the app on older devices. 14 is necessary for some methods of the ViewPropertyAnimator on the RecyclerView.
